### PR TITLE
feat(Ready); ReadyScene 유저 강퇴 기능 도입

### DIFF
--- a/Assets/Scripts/Ready/HandlePlayerSlot.cs
+++ b/Assets/Scripts/Ready/HandlePlayerSlot.cs
@@ -7,9 +7,8 @@ public class HandlePlayerSlot : MonoBehaviour
 {
     public bool IsFilled;
     public bool IsBlocked;
-
+    public int PlayerNum;
     public int SpriteColor;
-
 
     Toggle btnActiveToggle;
     // Child 0
@@ -59,8 +58,8 @@ public class HandlePlayerSlot : MonoBehaviour
 
     public void SetSlot(PlayerData _player)
     {
-        SetSlotState(true);
-
+        SetSlotState(true); ;
+        PlayerNum = _player.Id;
         playerName.text = _player.Name;
 
         isLeaderObj.SetActive(_player.IsMaster);
@@ -72,6 +71,7 @@ public class HandlePlayerSlot : MonoBehaviour
     public void SetEmptySlot(bool _blocked)
     {
         SetSlotState(false);
+        PlayerNum = -1;
 
         IsBlocked = _blocked;
 

--- a/Assets/Scripts/Ready/ReadyManager.cs
+++ b/Assets/Scripts/Ready/ReadyManager.cs
@@ -95,7 +95,7 @@ public class ReadyManager : MonoBehaviour
         }
         for (; index < StaticVars.MAX_PLAYERS_PER_ROOM; index++)
         {
-            playerSlots[index].SetEmptySlot(false);
+            playerSlots[index].SetEmptySlot((_availableSlots & (1 << index)) == 0);
         }
 
         // Start/Ready Btn UI

--- a/Assets/Scripts/Ready/ReadyManager.cs
+++ b/Assets/Scripts/Ready/ReadyManager.cs
@@ -125,6 +125,8 @@ public class ReadyManager : MonoBehaviour
 
     public void SetColorToggle(int _color)
     {
+        color = _color;
+
         int index= 0;
         while (_color > 1)
         {
@@ -145,5 +147,14 @@ public class ReadyManager : MonoBehaviour
     public void DisactivateColorToggle(bool _isReady)
     {
         ColorToggleDeactivatePanelObj.SetActive(_isReady);
+    }
+
+    public int GetPlayerId(int _index)
+    {
+        if (!playerSlots[_index].IsFilled) return -1;
+        else
+        {
+            return playerSlots[_index].PlayerNum;
+        }
     }
 }

--- a/Assets/Scripts/Utils/StaticCodes.cs
+++ b/Assets/Scripts/Utils/StaticCodes.cs
@@ -1,9 +1,10 @@
 public static class StaticCodes
 {
     #region Photon Property Keys
-    public static string PHOTON_PROP_COLOR = "p_color";
-    public static string PHOTON_PROP_ISREADY = "p_ready";
-    public static string PHOTON_PROP_SYNC = "p_sync";
-    public static string PHOTON_PROP_SLOTS = "p_slots";
+    public static string PHOTON_PROP_COLOR = "p_clr";
+    public static string PHOTON_PROP_ISREADY = "p_rdy";
+    public static string PHOTON_PROP_SYNC = "p_syn";
+    public static string PHOTON_PROP_SLOTS = "p_slt";
+    public static string PHOTON_PROP_KICKED = "p_kck";
     #endregion
 }


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) feat(Clue): set clue random position and type
        fix(Player): resolve player movement error
        refactor(UI): add UIManager
!-->
## 구현 내용
<!--
PR이 포함한 변경사항과 관련 스크립트와 에셋을 명시해주세요
    ex) 1. player movement
          - playerController.cs
          - Homes.prefab
!-->
1. feat: add player kick function
   * NetworkManager.cs
   * HandlePlayerSlot.cs
2. fix: 
   * .cs

<br>

## 수정 사항(TODO)
<!--
보완해야 할 사항을 적어주세요
!-->
- 현재 color 변경이 참가자는 isReady 누를 시에, master는 play 누를 시에 색깔이 서버로 전달되는데, 이렇게 하면 master는 색깔을 선점하지 못한다는 문제가 있습니다.. master의 color는 변경하는 게 바로바로 보이도록 도입할지 아님 구현 방식을 바꿔 모든 player들의 color를 바로 동기화되도록 할지 고민해 보아야 할 것 같습니다. 이건 그래도 로직상 큰 문제는 안되니까.. 시간 되면 다음에 더 나은 구현 방법을 생각해보겠습니다.

<br>

## 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
- 

